### PR TITLE
RFC 0016 - Mavlink Standard Modes

### DIFF
--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -290,6 +290,27 @@ But we could make this new setter command more generic `MAV_CMD_DO_SET_MODE_V2` 
       </entry>
 ```
 
+## Getting Available modes: Component Metadata rather than Message
+
+We could get the available mode information using a component metadata file.
+This has been discarded for now because component metadata has not yet formally part of the standard.
+It might reasonably replace or be used as well as the messages.
+
+The benefits are:
+- Can be extended easily with other metadata, including grouping of manual vs autonomous, standard vs custom. 
+- Provides mechanism for delivering standard documentation and additional descriptions of modes out of the box. 
+- Provides mechanism for delivering minor customisations of standard documentation out of the box - e.g. two flight stack both support standard orbit mode, but one controls altitude with sticks, and the other controls rotation direction.
+- Translation out of the box
+- Works for both custom and standard modes as peers - current approach does not allow anything other than one string for custom modes.
+- Get all the information at once using same infrastructure as for other data.
+- Avoids "yet another metadata" mechanism.
+
+The downsides are that
+- component information is not yet in the standard.
+- component information takes more effort to implement first time (e.g. mavftp, parsers), and more than parsing just a message.
+- It is less dynamic to update, though this can be supported if needed (i.e. for things like lua-script injected modes).
+
+
 ## Getting Available modes: Flags instead of mode enumeration
 
 Instead of enumerating all available modes we could define a flag indicating the _standard_ modes that are supported.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -1,0 +1,230 @@
+  * Start date: 2021-02-21
+  * Contributors: HamishWillee <hamishwillee@gmail.com>, Lorenz Meier <lorenz@px4.io>, ...
+  * Related issues: 
+    - Discussion PR: https://github.com/mavlink/mavlink/issues/1165, 
+    - Initial proposal: https://docs.google.com/document/d/1LIcfOL3JrX-EznvXArna1h-sZ7va7LRTteIUzISuD8c/edit
+
+# Summary
+
+This RFC proposes a microservice that will allow a GCS (or MAVLink SDK) to use a safely use a "standard" set of flight modes without any prior knowledge of a flight stack.
+
+The proposal defines a small (initial) set of standard autopilot modes, along with mechanism to query available modes, set the standard mode, and publish the current standard mode (if a standard mode is active).
+This is sufficient to determine what modes are supported, command a flight stack into a standard mode, and have it behave in a predictable way.
+
+The mechanism also enables, but does not define, standard modes for other non-autopilot components like cameras, gimbals, etc.
+
+The design uses a new message for returning the available modes, and for setting the standard mode.
+An extension field is added to the [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT) to publish the current standard mode (if enabled).
+
+The service is a pure addition: it has no impact or side effects when used with systems that do not implement or understand it.
+
+> **Note:** The proposed design allows both custom and standard modes to be discovered.
+> A GCS could therefore share these if desired, though without any semantic understanding of their meaning.
+
+
+# Motivation
+
+This service will allow a GCS to provide baseline support for common flight behaviour and test behaviour without explicit customisation for each autopilot.
+
+This is therefore a big step towards MAVLink being capable of being truly autopilot-agnostic for a useful minimal set of functionality.
+
+
+### Background
+
+MAVLink currently standardizes *very high level* _base modes_ (defined in [MAV_MODE](https://mavlink.io/en/messages/common.html#MAV_MODE)), which cover things like whether the vehicle is ready to fly, being tested, manually controlled, under GCS manual control, or executing a mission.
+
+More specific flight behaviour/modes are defined in _custom modes_, which are specific to each flight stack.
+Mechanisms are provided to set the base and custom modes ([MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE)).
+The `HEARTBEAT` contains the current/active `base_mode` and `custom_mode`. 
+There are no mechanisms query the available custom modes.
+
+Most autopilots implement a set of custom flight modes that have very similar behaviour, including: takeoff, land, safety return/RTL, position mode, altitude mode, mission mode, hold mode.
+However because these are all identified by different custom mode identifiers on different flight stacks, there is no way to be sure what these "mean" without pre-existing knowledge.
+
+
+# Detailed Design
+
+The design proposes a small set of modes that are (broadly speaking) commonly implemented across flight stacks, along with mechanisms to:
+- set the standard mode
+- get the current standard mode, if active.
+- determine what modes are available
+
+## Standard modes
+
+Standard modes are those that are implemented in a similar way by most flight stacks, and which a GCS can present as more or less the same thing for any flight stack.
+
+The precise mechanics and behaviour do not have to be identical, but the broad intent has to be similar.
+For example, most flight stacks have the concept of a safety return mode, which flies the vehicle back to a safe place.
+While the destination, path, and whether the vehicle lands may differ for a particular flight stack or based on settings, the concept is similar, and would not be unexpected by a user.
+
+The standard modes will be defined in an enum `MAV_STANDARD_MODE`, which has an initial value `0` is an enum that indicates "not a standard mode".
+
+The proposed initial set of modes is:
+```xml
+    <enum name="MAV_STANDARD_MODE">
+      <description>Standard modes with a well understood meaning across flight stacks and vehicle types.
+        For example, most flight stack have the concept of a "return" or "RTL" mode that takes a vehicle to safety, even though the precise mechanics of this mode may differ.
+        Modes may be set using MAV_CMD_DO_SET_STANDARD_MODE.
+      </description>
+      <entry value="0" name="MAV_STANDARD_MODE_NON_STANDARD">
+        <description>Non standard mode.
+          This may be used when reporting the mode if the current flight mode is not a standard mode.
+        </description>
+      </entry>
+      <entry value="1" name="MAV_STANDARD_MODE_POSITION_HOLD">
+        <description>Position mode (manual).
+          Position-controlled and stabilized manual mode.
+          When sticks are released vehicles return to their level-flight orientation.
+          Hovering vehicles actively brake and hold both position and altitude against wind and external forces,
+          Forward-traveling vehicles maintain current track and altitude.
+        </description>
+      </entry>
+      <entry value="2" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
+        <description>Altitude hold (manual).
+          Altitude-controlled and stabilized manual mode.
+          When sticks are released vehicles return to their level-flight orientation.
+          Hovering vehicles hold altitude but continue with existing momentum and may move with wind.
+          Forward-traveling vehicles maintain altitude but may be moved off their current heading by exernal forces.
+        </description>
+      </entry>
+      <entry value="3" name="MAV_STANDARD_MODE_SAFETY_RETURN">
+        <description>Return mode (auto).
+          Automatic mode that returns vehicle to a safe location via a safe flight path.
+          It may also automatically land the vehicle.
+          The precise return location, flight path, and landing behaviour depend on vehicle configuration and type.
+        </description>
+      </entry>
+      <entry value="4" name="MAV_STANDARD_MODE_LAND">
+        <description>Land mode (auto).
+          Automatic mode that lands the vehicle at the current location.
+          The precise landing behaviour depends on vehicle configuration and type.
+        </description>
+      </entry>
+      <entry value="5" name="MAV_STANDARD_MODE_TAKEOFF">
+        <description>Takeoff mode (auto).
+          Automatic takeoff mode.
+          The precise takeoff behaviour depends on vehicle configuration and type.
+        </description>
+      </entry>
+      <entry value="6" name="MAV_STANDARD_MODE_MISSION">
+        <description>Mission mode (automatic).
+          Automatic mode that executes MAVLink missions.
+          Missions are executed from the current waypoint as soon as the mode is enabled.
+          If a mission cannot be executed the mission is paused.
+        </description>
+      </entry>
+    </enum>
+```
+
+In future this may be extended with additional flight modes and component specific modes.
+
+
+## Setting Modes
+
+The mode will be set using a new command: `MAV_CMD_DO_SET_STANDARD_MODE`.
+
+```xml
+      <entry value="262" name="MAV_CMD_DO_SET_STANDARD_MODE" hasLocation="false" isDestination="false">
+        <description>Enable the specified standard MAVLink mode.
+          If the mode is not supported the vehicle should ACK with MAV_RESULT_FAILED.
+        </description>
+        <param index="1" label="Standard Mode" enum="MAV_STANDARD_MODE">The mode to set.</param>
+        <param index="2" reserved="true" default="0"/>
+        <param index="3" reserved="true" default="0"/>
+        <param index="4" reserved="true" default="0"/>
+        <param index="5" reserved="true" default="0"/>
+        <param index="6" reserved="true" default="0"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+```
+
+> **Note:** 
+> - Preferably we would extend [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) to set the standard mode using `param4`.
+>   This is risky because a system that does not support the service will try to set the base and custom modes.
+> - We could make this command more generic `MAV_CMD_DO_SET_MODE_V2` and include custom and base modes in it too.
+
+## Getting Available Modes
+
+A new message will be added for enumerating all available modes (standard, base, and custom) for the current vehicle type:
+- The message will include the total number of modes and the index of the current mode.
+  This indexing is provided to allow a GCS to confirm that all modes have been collector and re-request any that are missing.
+  It is internal and should not be relied upon to have any order between reboots.
+- If there is a direct correlation between a standard mode and a custom mode this should be treated as just one mode (the standard mode) and emitted once.
+- The GCS can request this message using `MAV_CMD_REQUEST_MESSAGE`, specifying either "send all modes" or "send mode with this index".
+- The message will include a mode name that will be used to provide a string for the GCS to represent custom modes.
+  It would be empty for standard modes, for which name strings and translations may be hard coded into the GCS.
+- The flight should only emit each mode once.
+  If a mode is both custom and standard it should be emitted as a "standard mode" (this allows the GCS to list the "standard modes" and separately show the additional "custom modes").
+- The modes that are emitted depend on the current vehicle type.
+  For example, "takeoff" would not be emitted for a rover type, but would for a copter.
+
+A proposal for the message is provided below.
+
+```xml
+    <message id="435" name="AVAILABLE_MODES">
+      <description>Get information about a particular flight modes.
+        The message can be enumerated or requested for a particular mode using MAV_CMD_REQUEST_MESSAGE.
+        Specify 0 in param2 to request that the message is emitted for all available modes or the specific index for just one mode.
+        The modes must be available/settable for the current vehicle/frame type.
+        Each modes should only be emitted once (even if it is both standard and custom).
+      </description>
+      <field type="uint8_t" name="number_modes">The total number of available modes for the current vehicle type.</field>
+      <field type="uint8_t" name="mode_index">The current mode index within number_modes, indexed from 1.</field>
+      <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
+      <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
+      <field type="char[50]" name="mode_name">Name of custom mode, without null termination character. Should be omitted for standard modes.</field>
+    </message>
+```
+
+> **Note** This message provides all modes.
+> If we only want to get standard modes (not enumerate custom modes we might instead) the message could just list the enum values for supported modes (i.e. in a comma separated string, or an array of values.
+
+## Getting Current Standard Mode
+
+The current standard mode will be added to [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT) as an extension field.
+This allows it to be obtained alongside the base and custom modes.
+Metadata about the mode is either from the standard mode definitions or simply a name provided for custom-only modes.
+
+```xml
+      <extensions/>
+      <field type="uint16_t" name="standard_mode" enum="MAV_STANDARD_MODE">The current active standard mode (or 0 for a custom-only mode).</field>
+```
+
+Notes:
+- A separate message was considered, in particular because `HEARTBEAT` is so critical.
+  However this is the logical and consistent way to share modes.
+- The mode is a double byte to allow the `MAV_STANDARD_MODE` to be extended to support non-autopilot modes in future.
+
+
+# Alternatives
+
+## Use standard commands rather than standard modes
+
+The main goal is to allow a vehicle to be put into standard "flight behaviours".
+This could also be done by defining suitably generic commands: e.g. [MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF).
+
+Modes have the slight benefit that the commands already have definitions which may not be suitably generic.
+Further commands do not have to match a specific mode in all cases: using modes means that the behaviour will have an expected display in the UI.
+
+## Only expose custom modes
+
+Just implementing `AVAILABLE_MODES` would allow an anonymous flight stack to be used by a ground station in a limited way.
+
+However there would be no reliable common understanding of what each of the modes meant or what they actually are, so a GCS could not necessarily provide useful information to a user other than the name of the mode that has been entered.
+
+
+
+# Unresolved Questions
+
+- Can we we provide more information about the current mode. E.g. in return mode, the user doesn't care about the behaviour, but a GCS might better configure itself if it knows that rally points are being used, or a mission landing.
+- What modes make sense for other components? Camera etc.
+
+
+# References
+
+* PRs/Issues for discussion:
+  - https://github.com/mavlink/mavlink/pull/1750
+  - https://github.com/mavlink/mavlink/issues/1165
+  - [Initial proposal google doc](https://docs.google.com/document/d/1LIcfOL3JrX-EznvXArna1h-sZ7va7LRTteIUzISuD8c/edit) - mostly a problem statement.
+  

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -78,7 +78,7 @@ The proposed initial set of modes is:
           Position-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation.
           Multicopter (MC) vehicles actively brake and hold both position and altitude against wind and external forces.
-          Fixed-wing (FW) vehicles maintain current track and altitude.
+          Fixed-wing (FW) vehicles maintain current track and altitude against wind and external forces.
           Hybrid MC/FW  ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
           Other vehicle types should not return this mode (this may be revisited through the PR process).
         </description>

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -232,24 +232,32 @@ This would be emitted on mode change, and also streamed at low rate (a GCS might
 
 Note that the current base and custom modes are currently (and should continue to be) published in the [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT).
 Including the standard mode in the `HEARTBEAT` was discussed and discarded.
-See "Getting current mode: Use Heartbeat" below.
+See "Get Current mode from HEARTBEAT" section below.
 
 
 # Alternatives
 
-## Current mode: Infer from custom/base modes
+## Get Current mode from HEARTBEAT
 
 The current base and custom modes are currently published in the [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT).
-The proposal is to add the standard mode to `HEARTBEAT` as an extension field.
-There are several reasons for this, one being that this is where the other mode information is. 
+The proposal is to get the current standard mode using a separate message.
 
 We could instead:
-- Publish mode in a separate mode message
 - Infer the current standard mode from the custom/base modes in `HEARTBEAT`
+- Publish the current standard mode as an extension field in the `HEARTBEAT`.
+- Publish mode in a separate mode message
 
-The argument for using a separate message for getting the mode is that mode information should not be in the `HEARTBEAT` anyway.
-The heartbeat is for indicating connection; using it for modes does not make sense for autopilots particularly and none for other components.
-We could publish this separately, giving us a path for eventually moving to "HEARTBEAT2"
+The original proposal was to add the standard mode to `HEARTBEAT` as an extension field, as this is the easiest for flight stacks/SDKs to use:
+
+```xml
+      <extensions/>
+      <field type="uint16_t" name="standard_mode" enum="MAV_STANDARD_MODE">The current active standard mode (or 0 for a custom-only mode).</field>
+```
+
+The arguments against were:
+- `HEARTBEAT` is absolutely core to MAVLink. It is risky to update.
+- Modes logically shouldn't be in the `HEARTBEAT` - extending this with standard modes is compounding the issue.
+- Having a separate message means that this is completely separate/orthogonal to the existing implementation.
 
 We might also infer the current standard mode from the existing base and custom mode fields in the `HEARTBEAT`.
 This would mean that the message would not have to change, but would have the following implications:
@@ -331,18 +339,6 @@ This could also be done by defining suitably generic commands: e.g. [MAV_CMD_NAV
 Modes have the slight benefit that the commands already have definitions which may not be suitably generic.
 Further commands do not have to match a specific mode in all cases: using modes means that the behaviour will have an expected display in the UI.
 
-## Getting current mode: Use Heartbeat
-
-The original proposal was to add the standard mode to `HEARTBEAT` as an extension field, as this is the easiest for flight stacks/SDKs to use:
-
-```xml
-      <extensions/>
-      <field type="uint16_t" name="standard_mode" enum="MAV_STANDARD_MODE">The current active standard mode (or 0 for a custom-only mode).</field>
-```
-
-The arguments against were:
-- `HEARTBEAT` is absolutely core to MAVLink. It is risky to update.
-- Modes logically shouldn't be in the `HEARTBEAT` - extending this with standard modes is compounding the issue.
 
 # Unresolved Questions
 

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -6,7 +6,7 @@
 
 # Summary
 
-This RFC proposes a microservice that will allow a GCS (or MAVLink SDK) to use a safely use a "standard" set of flight modes without any prior knowledge of a flight stack.
+This RFC proposes a microservice that will allow a GCS (or MAVLink SDK) to safely use a "standard" set of flight modes without any prior knowledge of a flight stack.
 
 The proposal defines a small (initial) set of standard autopilot modes, along with mechanism to query available modes, set the standard mode, and determine the current standard mode (if a standard mode is active).
 This is sufficient to determine what modes are supported, command a flight stack into a standard mode, and have it behave in a predictable way.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -77,16 +77,20 @@ The proposed initial set of modes is:
         <description>Position mode (manual).
           Position-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation.
-          Hovering vehicles actively brake and hold both position and altitude against wind and external forces,
-          Forward-traveling vehicles maintain current track and altitude.
+          Multicopter (MC) vehicles actively brake and hold both position and altitude against wind and external forces.
+          Fixed-wing (FW) vehicles maintain current track and altitude.
+          Hybrid MC/FW  ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
+          Other vehicle types should not return this mode (this may be revisited through the PR process).
         </description>
       </entry>
       <entry value="2" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
         <description>Altitude hold (manual).
           Altitude-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation.
-          Hovering vehicles hold altitude but continue with existing momentum and may move with wind.
-          Forward-traveling vehicles maintain altitude but may be moved off their current heading by exernal forces.
+          MC vehicles hold altitude but continue with existing momentum and may move with wind.
+          FW vehicles maintain altitude but may be moved off their current heading by external forces.
+          Hybrid MC/FW ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
+          Other vehicle types should not return this mode (this may be revisited through the PR process).
         </description>
       </entry>
       <entry value="3" name="MAV_STANDARD_MODE_RETURN_HOME">

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -207,7 +207,7 @@ A proposal for the message is provided below.
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
-      <field type="char[50]" name="mode_name">Name of custom mode, without null termination character. Should be omitted for standard modes.</field>
+      <field type="char[50]" name="mode_name">Name of custom mode, with null termination character. Should be omitted for standard modes.</field>
     </message>
 ```
 

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -55,7 +55,7 @@ The design proposes a small set of modes that are (broadly speaking) commonly im
 
 Standard modes are those that are implemented in a similar way by most flight stacks, and which a GCS can present as more or less the same thing for any flight stack.
 
-The precise mechanics and behaviour do not have to be identical, but the broad intent has to be similar, and any differing behaviour across flight statcks should not be unexpected by a user.
+The precise mechanics and behaviour do not have to be identical, but the broad intent has to be similar, and any differing behaviour across flight stacks should not be unexpected by a user.
 
 A flight stack is not _required_ to support all of these modes.
 
@@ -77,14 +77,25 @@ The proposed initial set of modes is:
         <description>Position mode (manual).
           Position-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation and hold both position and altitude against wind and external forces.
-          Note that the precise meaning of "hold position" depends on vehicle type (for example, an MC can hold to a specify point, while a boat might either loiter around a circle centered on fixed point or drift within that circle).
+          This mode can only be set by vehicles that can hold a fixed position.
           Multicopter (MC) vehicles actively brake and hold both position and altitude against wind and external forces.
           Hybrid MC/FW ("VTOL") vehicles first transition to multicopter mode (if needed) but otherwise behave in the same way as MC vehicles.
           Fixed-wing (FW) vehicles may not support this mode.
           Other vehicle types may not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="2" name="MAV_STANDARD_MODE_CRUISE">
+      <entry value="2" name="MAV_STANDARD_MODE_ORBIT">
+        <description>Orbit (manual).
+          Position-controlled and stabilized manual mode.
+          The vehicle circles around a fixed setpoint in the horizontal plane at a particular radius, altitude, and direction.
+          Flight stacks may further allow manual control over the setpoint position, radius, direction, speed, and/or altitude of the circle, but this is not mandated.
+          Flight stacks may support the [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) for changing the orbit parameters.
+          MC and FW vehicles may support this mode.
+          Hybrid MC/FW ("VTOL") vehicles may support this mode in MC/FW or both modes; if the mode is not supported by the current configuration the vehicle should transition to the supported configuration.
+          Other vehicle types may not support this mode (this may be revisited through the PR process).
+        </description>
+      </entry>
+      <entry value="3" name="MAV_STANDARD_MODE_CRUISE">
         <description>Cruise mode (manual).
           Position-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation and hold their original track against wind and external forces.
@@ -94,7 +105,7 @@ The proposed initial set of modes is:
           Other vehicle types may not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="3" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
+      <entry value="4" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
         <description>Altitude hold (manual).
           Altitude-controlled and stabilized manual mode.
           When sticks are released vehicles return to their level-flight orientation and hold their altitude.
@@ -104,33 +115,34 @@ The proposed initial set of modes is:
           Other vehicle types may not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="4" name="MAV_STANDARD_MODE_RETURN_HOME">
+
+      <entry value="5" name="MAV_STANDARD_MODE_RETURN_HOME">
         <description>Return home mode (auto).
           Automatic mode that returns vehicle to home via a safe flight path.
           It may also automatically land the vehicle (i.e. RTL).
           The precise flight path and landing behaviour depend on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="5" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
+      <entry value="6" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
         <description>Safe recovery mode (auto).
           Automatic mode that takes vehicle to a predefined safe location via a safe flight path (rally point or mission defined landing) .
           It may also automatically land the vehicle.
           The precise return location, flight path, and landing behaviour depend on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="6" name="MAV_STANDARD_MODE_MISSION">
+      <entry value="7" name="MAV_STANDARD_MODE_MISSION">
         <description>Mission mode (automatic).
           Automatic mode that executes MAVLink missions.
           Missions are executed from the current waypoint as soon as the mode is enabled.
         </description>
       </entry>
-      <entry value="7" name="MAV_STANDARD_MODE_LAND">
+      <entry value="8" name="MAV_STANDARD_MODE_LAND">
         <description>Land mode (auto).
           Automatic mode that lands the vehicle at the current location.
           The precise landing behaviour depends on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="8" name="MAV_STANDARD_MODE_TAKEOFF">
+      <entry value="9" name="MAV_STANDARD_MODE_TAKEOFF">
         <description>Takeoff mode (auto).
           Automatic takeoff mode.
           The precise takeoff behaviour depends on vehicle configuration and type.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -76,50 +76,61 @@ The proposed initial set of modes is:
       <entry value="1" name="MAV_STANDARD_MODE_POSITION_HOLD">
         <description>Position mode (manual).
           Position-controlled and stabilized manual mode.
-          When sticks are released vehicles return to their level-flight orientation.
+          When sticks are released vehicles return to their level-flight orientation and hold both position and altitude against wind and external forces.
+          Note that the precise meaning of "hold position" depends on vehicle type (for example, an MC can hold to a specify point, while a boat might either loiter around a circle centered on fixed point or drift within that circle).
           Multicopter (MC) vehicles actively brake and hold both position and altitude against wind and external forces.
-          Fixed-wing (FW) vehicles maintain current track and altitude against wind and external forces.
-          Hybrid MC/FW  ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
-          Other vehicle types should not return this mode (this may be revisited through the PR process).
+          Hybrid MC/FW ("VTOL") vehicles first transition to multicopter mode (if needed) but otherwise behave in the same way as MC vehicles.
+          Fixed-wing (FW) vehicles may not support this mode.
+          Other vehicle types may not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="2" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
+      <entry value="2" name="MAV_STANDARD_MODE_CRUISE">
+        <description>Cruise mode (manual).
+          Position-controlled and stabilized manual mode.
+          When sticks are released vehicles return to their level-flight orientation and hold their original track against wind and external forces.
+          Fixed-wing (FW) vehicles level orientation and maintain current track and altitude against wind and external forces.
+          Hybrid MC/FW ("VTOL") vehicles first transition to FW mode (if needed) but otherwise behave in the same way as MC vehicles.
+          Multicopter (MC) vehicles may not support this mode.
+          Other vehicle types may not support this mode (this may be revisited through the PR process).
+        </description>
+      </entry>
+      <entry value="3" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
         <description>Altitude hold (manual).
           Altitude-controlled and stabilized manual mode.
-          When sticks are released vehicles return to their level-flight orientation.
-          MC vehicles hold altitude but continue with existing momentum and may move with wind.
-          FW vehicles maintain altitude but may be moved off their current heading by external forces.
+          When sticks are released vehicles return to their level-flight orientation and hold their altitude.
+          MC vehicles continue with existing momentum and may move with wind (or other external forces).
+          FW vehicles continue with current heading, but may be moved off-track by wind.
           Hybrid MC/FW ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
-          Other vehicle types should not return this mode (this may be revisited through the PR process).
+          Other vehicle types may not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="3" name="MAV_STANDARD_MODE_RETURN_HOME">
+      <entry value="4" name="MAV_STANDARD_MODE_RETURN_HOME">
         <description>Return home mode (auto).
           Automatic mode that returns vehicle to home via a safe flight path.
           It may also automatically land the vehicle (i.e. RTL).
           The precise flight path and landing behaviour depend on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="4" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
+      <entry value="5" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
         <description>Safe recovery mode (auto).
           Automatic mode that takes vehicle to a predefined safe location via a safe flight path (rally point or mission defined landing) .
           It may also automatically land the vehicle.
           The precise return location, flight path, and landing behaviour depend on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="5" name="MAV_STANDARD_MODE_MISSION">
+      <entry value="6" name="MAV_STANDARD_MODE_MISSION">
         <description>Mission mode (automatic).
           Automatic mode that executes MAVLink missions.
           Missions are executed from the current waypoint as soon as the mode is enabled.
         </description>
       </entry>
-      <entry value="6" name="MAV_STANDARD_MODE_LAND">
+      <entry value="7" name="MAV_STANDARD_MODE_LAND">
         <description>Land mode (auto).
           Automatic mode that lands the vehicle at the current location.
           The precise landing behaviour depends on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="7" name="MAV_STANDARD_MODE_TAKEOFF">
+      <entry value="8" name="MAV_STANDARD_MODE_TAKEOFF">
         <description>Takeoff mode (auto).
           Automatic takeoff mode.
           The precise takeoff behaviour depends on vehicle configuration and type.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -80,8 +80,8 @@ The proposed initial set of modes is:
           This mode can only be set by vehicles that can hold a fixed position.
           Multicopter (MC) vehicles actively brake and hold both position and altitude against wind and external forces.
           Hybrid MC/FW ("VTOL") vehicles first transition to multicopter mode (if needed) but otherwise behave in the same way as MC vehicles.
-          Fixed-wing (FW) vehicles may not support this mode.
-          Other vehicle types may not support this mode (this may be revisited through the PR process).
+          Fixed-wing (FW) vehicles must not support this mode.
+          Other vehicle types must not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
       <entry value="2" name="MAV_STANDARD_MODE_ORBIT">
@@ -92,7 +92,7 @@ The proposed initial set of modes is:
           Flight stacks may support the [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) for changing the orbit parameters.
           MC and FW vehicles may support this mode.
           Hybrid MC/FW ("VTOL") vehicles may support this mode in MC/FW or both modes; if the mode is not supported by the current configuration the vehicle should transition to the supported configuration.
-          Other vehicle types may not support this mode (this may be revisited through the PR process).
+          Other vehicle types must not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
       <entry value="3" name="MAV_STANDARD_MODE_CRUISE">
@@ -101,8 +101,8 @@ The proposed initial set of modes is:
           When sticks are released vehicles return to their level-flight orientation and hold their original track against wind and external forces.
           Fixed-wing (FW) vehicles level orientation and maintain current track and altitude against wind and external forces.
           Hybrid MC/FW ("VTOL") vehicles first transition to FW mode (if needed) but otherwise behave in the same way as MC vehicles.
-          Multicopter (MC) vehicles may not support this mode.
-          Other vehicle types may not support this mode (this may be revisited through the PR process).
+          Multicopter (MC) vehicles must not support this mode.
+          Other vehicle types must not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
       <entry value="4" name="MAV_STANDARD_MODE_ALTITUDE_HOLD">
@@ -112,7 +112,7 @@ The proposed initial set of modes is:
           MC vehicles continue with existing momentum and may move with wind (or other external forces).
           FW vehicles continue with current heading, but may be moved off-track by wind.
           Hybrid MC/FW ("VTOL") vehicles behave according to their current configuration/mode (FW or MC).
-          Other vehicle types may not support this mode (this may be revisited through the PR process).
+          Other vehicle types must not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
 

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -207,6 +207,24 @@ This could also be done by defining suitably generic commands: e.g. [MAV_CMD_NAV
 Modes have the slight benefit that the commands already have definitions which may not be suitably generic.
 Further commands do not have to match a specific mode in all cases: using modes means that the behaviour will have an expected display in the UI.
 
+
+## Only expose standard modes
+
+`AVAILABLE_MODES` (as designed) is emitted for all modes.
+
+This is useful as it allows a UI where the GCS can display all the standard modes if it wants, or all the standard modes and separately all the custom modes (albeit these could not be translated etc).
+
+However this may be unnecessarily complicated. If we agree that we only need to list the supported modes then we could simplify work for the GCS by providing all the supported modes in a single message. Something like:
+
+```xml
+    <message id="435" name="AVAILABLE_MODES">
+      <description>Get the list of all available standard modes.
+        The message can be requested using MAV_CMD_REQUEST_MESSAGE.
+      </description>
+      <field type="char[250]" name="modes">List of enum values for all standard modes, comma separated, without null termination character.</field>
+    </message>
+```
+
 ## Only expose custom modes
 
 Just implementing `AVAILABLE_MODES` would allow an anonymous flight stack to be used by a ground station in a limited way.
@@ -216,6 +234,8 @@ However there would be no reliable common understanding of what each of the mode
 
 
 # Unresolved Questions
+
+- Do we need support for getting available custom modes? If we only need standard modes then we could have a much simpler `AVAILABLE_MODES` and much easier interaction for GCS.
 
 - Can we we provide more information about the current mode. E.g. in return mode, the user doesn't care about the behaviour, but a GCS might better configure itself if it knows that rally points are being used, or a mission landing.
 - What modes make sense for other components? Camera etc.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -107,7 +107,6 @@ The proposed initial set of modes is:
         <description>Mission mode (automatic).
           Automatic mode that executes MAVLink missions.
           Missions are executed from the current waypoint as soon as the mode is enabled.
-          If a mission cannot be executed the mission is paused.
         </description>
       </entry>
       <entry value="6" name="MAV_STANDARD_MODE_LAND">

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -1,4 +1,7 @@
   * Start date: 2021-02-21
+  * State: Accepted Draft (2023-04-26)
+    - Accepted in principle
+    - Not prototyped and therefore expected to change
   * Contributors: HamishWillee <hamishwillee@gmail.com>, Lorenz Meier <lorenz@px4.io>, ...
   * Related issues: 
     - Discussion PR: https://github.com/mavlink/mavlink/issues/1165, 


### PR DESCRIPTION
This RFC proposes a microservice that will allow a GCS (or MAVLink SDK) to use a safely use a "standard" set of flight modes without any prior knowledge of a flight stack.

The proposal defines a small (initial) set of standard autopilot modes, along with mechanism to query available modes, set the standard mode, and publish the current standard mode (if a standard mode is active).

This is sufficient to determine what modes are supported, command a flight stack into a standard mode, and have it behave in a predictable way.

EDITED: STATUS
- This has been "approved for testing". The messages defined in the proposal are now present in development.xml.
- PX4 issue: https://github.com/PX4/PX4-Autopilot/issues/19197