### PR TITLE
RFC 0018 - Improved Battery Status Reporting 

### DIFF
--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -59,7 +59,7 @@ With `MAV_BATTERY_FAULT` having the following **additions** (from `MAV_BATTERY_C
       <entry value="1024" name="BATTERY_FAULT_AUTO_DISCHARGING">
         <description>Battery is auto discharging (towards storage level). Not ready to use.</description>
       </entry>
-      <entry value="1024" name="BATTERY_FAULT_HOT_SWAP">
+      <entry value="2048" name="BATTERY_FAULT_HOT_SWAP">
         <description>Battery in hot-swap mode (current limited to prevent spikes that might damage sensitive electrical circuits). Not ready to use.</description>
       </entry>
 ```

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -169,18 +169,18 @@ The proposed message is:
 
 The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
-- adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
-- `current_consumed` has changed to capacity_consumed, and from an `int32_t` to a `uint32_t`.
-  This future proofs from 32767 mAh limit to 4294967295 mAh 
+- adds `voltage`, the total cell voltage. This is a float to allow batteries with more than 65V and also very small voltage changes.
+- `current_consumed` has changed to capacity_consumed, and from an `int32_t` to a `float` in A.
+  This future proofs from 32767 mAh limit and allows very large and very small values.
 - removes `energy_consumed`, which essentially duplicates `capacity_consumed` for most purposes, and `capacity_consumed` in mAh is nearly ubiquitous.
-- adds `capacity_remaining`(mAh).
+- adds `capacity_remaining`(Ah) as a `float`.
   - This allows a GCS to more accurately determine available current and remaining time than inferring from the `capacity_consumed` and `percent_remaining`.
   - This will be reliable for smart batteries.
   - A flag has been added to indicate whether this is calculated from an assumed or known-full battery.
     A GCS can use this to prompt that batteries be fully charged for power modules.
 - Note that with capacity consumed and remaining, you have the full capacity and you could calculate the percentage remaining.
   However percentage remaining is supplied anyway, as the other values are optional, and this is actually the one value that most users really want.
-- change `current` from a `int16_t` (cA) to a `int32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof. New value gives up to 2,147,483A. The value is positive when discharging, and negative when charging.
+- change `current` from a `int16_t` (cA) to a `float` (A). Maximum size was previously 327.67A, which is not large enough to be future proof. New value gives full range and both very small and very high values.
 - removes `time_remaining`.
   ```xml
   <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -63,7 +63,7 @@ The proposed message is:
       <entry value="1" name="MAV_BATTERY_STATUS_FLAGS_READY_TO_USE">
         <description>
           The battery is ready to use (fly).
-          Only set if the battery is safe and ready to fly with (not charging, no critical faults, such as those that would set MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE or MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY, etc.).
+          Set if the battery has no known issues that would make it unsafe to fly with. This includes critical faults, such as those that would set MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE or MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY).
         </description>
       </entry>
       <entry value="2" name="MAV_BATTERY_STATUS_FLAGS_CHARGING">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -231,9 +231,9 @@ The proposed battery message is:
         This message is provided primarily for cell fault debugging.
         For batteries with more than 12 cells the message should be sent multiple times, iterating the index value.
         It should be streamed at very low rate (less than once a minute) or streamed only on request.</description>
-      <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>
-      <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 12 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
+      <field type="uint16_t" name="id" instance="true">Battery ID</field>
+      <field type="uint16_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>
+      <field type="uint16_t[126]" name="voltages" units="mV" invalid="[0]">Battery voltage of up to 126 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
     </message>
 ```
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -32,19 +32,11 @@ There are three parts to the design:
 
 ## BATTERY_STATUS_V2
 
-The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
-- removes the cell voltage arrays: `voltages` and `voltages_ext`
-- adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
-- removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
-- removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant. A GCS that needs this information should request it from that message on startup. NOTE THIS MEANS that either the chemistry and function of a particular battery ID must be invariant OR the message must be streamed. Otherwise there is no way to detect a battery change.
-  ```xml
-     <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
-      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
-  ```
+The proposed message is:
 
 ```xml
     <message id="???" name="BATTERY_STATUS_V2">
-      <description>Battery information. Updates GCS with flight controller battery status. Smart batteries also use this message, but may additionally send SMART_BATTERY_INFO.</description>
+      <description>Battery dynamic information. This should be streamed (nominally at 1Hz). Static battery information is sent in SMART_BATTERY_INFO.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX for unknown temperature.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
@@ -58,34 +50,70 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
     </message>
 ```
 
+The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
+- removes the cell voltage arrays: `voltages` and `voltages_ext`
+- adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
+- removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
+- removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant.
+  ```xml
+     <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+     <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+  ```
+  - A GCS that needs invariant information should read `SMART_BATTERY_INFO` on startup
+  - A vehicle that allows battery swapping must stream `SMART_BATTERY_INFO` (at low rate) to ensure that battery changes are notifie (and ideally also emit it on battery change).
 
-Questions:
+#### Questions
 
 - Do we need all the other fields?
 - Are there any other fields missing?
 
 
-## Battery Voltages
+## Battery Cell Voltages
 
-The proposed battery message is below.
-
-This assumes that the reason you might need the individual battery voltages is in order to identify that a particular cell has a significantly different voltage, and is hence in fault.
-It simply sends information about which cells are in fault, providing battery manufacturers a way of reporting more detailed debugging information.
+The proposed battery message is:
 
 ```xml
-    <message id="???" name="BATTERY_VOLTAGE_FAULT">
-      <description>Battery information. Updates GCS with flight controller battery status. Smart batteries also use this message, but may additionally send SMART_BATTERY_INFO.</description>
+    <message id="???" name="BATTERY_CELL_VOLTAGES">
+      <description>Battery cell voltages.
+        This message is provided primarily for cell fault debugging.
+	For batteries with more than 10 cells the message should be sent multiple times, iterating the index value.
+	It should not be streamed at very low rate (less than once a minute) or streamed only on request.</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 10 cells.</field>
+      <field type="uint16_t[10]" name="voltages" units="mV" invalid="[0]">Battery voltage of 10 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
+    </message>
+```
+
+Cell voltages can be used to verify that poorly performing batteries have failing cells, and to providing early warning of longer term battery degradation.
+It is useful to have long term trace information in logs, but not necessary for this to be at particularly high rate.
+Therefore the message provides all information about the battery voltages, but is expected to be sent at low rate, or on request.
+
+As designed, the message will not be zero-byte truncated (field re-ordering means that the array is last).
+The message might be modified to make:
+- `voltages` an extension field. For a 4S battery this would save 12 bytes per message but lose checking. If we do this we might as well mandate "no extension".
+- `id` and `index` into `uint16_t`. For a 4S battery this would save 10 bytes per message,and retain mavlink checking on field. It would cost 2 additional bytes on every new message.
+
+
+#### Alternatives
+
+An alternative is just to send fault information.
+This assumes that the smart battery is capable of providing the long term trend analysis that can be obtained from logs using the above message.
+
+```xml
+    <message id="???" name="BATTERY_CELL_VOLTAGES">
+      <description>Battery cell fault information.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="uint8_t" name="index">Cell index (0 by default). This is iterated for every 64 cells, allowing very large cell fault information. </field>
-      <field type="uint64_t" name="fault_mask">Fault/health indications. .</field>
+      <field type="uint64_t" name="fault_mask">Fault/health indications.</field>
     </message>
 ```
 
 ## SMART_BATTERY_INFO
 
-No changes are required to [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO).
+No changes are required to [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO) fields
 
-Note however that it must be streamed at a low rate in order to allow detection of battery change.
+Note however that it must be streamed at a low rate in order to allow detection of battery change, and should also be sent when the battery changes. 
+We should specify the rate.
 
 Questions:
 - What low rate is OK for streaming? is there another alternative?
@@ -112,7 +140,6 @@ TBD
 TBD
 
 # References
-  * ?
 
-
+* ?
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -161,6 +161,9 @@ The proposed message is:
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
+      <entry value="4,294,967,295" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
+        <description>Reserved (not used). If set, this will indicate that an additional status field exists for higher status values.</description>
+      </entry>
     </enum>
 ```
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -37,7 +37,7 @@ There are three parts to the design:
 The proposed message is:
 
 ```xml
-    <message id="???" name="BATTERY_STATUS_V2">
+    <message id="369" name="BATTERY_STATUS_V2">
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).
         Static/invariant battery information is sent in SMART_BATTERY_INFO.
@@ -215,11 +215,11 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 The proposed battery message is:
 
 ```xml
-    <message id="???" name="BATTERY_CELL_VOLTAGES">
+    <message id="371" name="BATTERY_CELL_VOLTAGES">
       <description>Battery cell voltages.
         This message is provided primarily for cell fault debugging.
         For batteries with more than 10 cells the message should be sent multiple times, iterating the index value.
-        It should not be streamed at very low rate (less than once a minute) or streamed only on request.</description>
+        It should be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>
       <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 12 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -81,7 +81,7 @@ The proposed battery message is:
 	It should not be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 10 cells.</field>
-      <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 10 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
+      <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 12 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
     </message>
 ```
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -50,7 +50,7 @@ The proposed message is:
       <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="capacity_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge. UINT32_MAX: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
       <field type="uint32_t" name="capacity_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
-      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
+      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="uint32_t" name="status_flags" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
 ```

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -47,7 +47,7 @@ The proposed message is:
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
-      <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
+      <field type="int32_t" name="current" units="mA" invalid="INT32_MAX">Battery current (through all cells/loads). Positive value when discharging and negative if charging. INT32_MAX: field not provided.</field>
       <field type="uint32_t" name="capacity_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge. UINT32_MAX: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
       <field type="uint32_t" name="capacity_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -1,0 +1,110 @@
+  * Start date: 2022-03-26
+  * Contributors: Hamish Willee <hamishwillee@gmail.com>, ...
+  * Related issues: 
+    - [16-cell support #1747](https://github.com/mavlink/mavlink/pull/1747)
+	- [common: added voltage and current multipliers to BATTERY_STATUS #233](https://github.com/ArduPilot/mavlink/pull/233)
+
+  
+# Summary
+
+This RFC proposes:
+- a new `BATTERY_STATUS_V2` message that has a single cumulative voltage value rather than individual cell voltage arrays.
+- a new (optional) `BATTERY_VOLTAGES` message that can be scaled to as many cells as needed, and which reports them as faults.
+- mechanisms to ease supporting both message types until we can eventually deprecate `BATTERY_STATUS`
+
+  
+# Motivation
+
+The motivation is to:
+- reduce the memory required for battery reporting ([anecdotal evidence](https://github.com/ArduPilot/mavlink/pull/233#issuecomment-976197179) indicates cases with 15% of bandwidth on a default RF channel).
+- Provide a cleaner message and design for both implementers and consumers.
+
+The [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) has two arrays that can be used to report individual cell voltages (up to 14), or a single cumulative voltage, and which cannot be truncated.
+The vast majority of consumers are only interested in the total battery voltage, and either sum the battery cells or get the cumulative voltage.
+By separating the cell voltage reporting into a separate message the new battery status can be much smaller, and the cell voltages need only be sent if the consumer is actually interested.
+
+# Detailed Design
+
+There are three parts to the design:
+1. A more efficient status message
+2. A scalable battery voltage message.
+3. Mechanisms that allow the new messages to seamlessly coexist with the old one along with eventual deprecation of the older message.
+
+## BATTERY_STATUS_V2
+
+The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
+- removes the cell voltage arrays: `voltages` and `voltages_ext`
+- adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
+
+
+```xml
+    <message id="???" name="BATTERY_STATUS_V2">
+      <description>Battery information. Updates GCS with flight controller battery status. Smart batteries also use this message, but may additionally send SMART_BATTERY_INFO.</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+      <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX for unknown temperature.</field>
+      <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
+      <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
+      <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
+      <field type="int32_t" name="energy_consumed" units="hJ" invalid="-1">Consumed energy, -1: Energy consumption estimate not provided.</field>
+      <field type="int8_t" name="battery_remaining" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: Remaining battery energy is not provided.</field>
+      <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
+      <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
+      <field type="uint8_t" name="mode" enum="MAV_BATTERY_MODE">Battery mode. Default (0) is that battery mode reporting is not supported or battery is in normal-use mode.</field>
+      <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health indications. These should be set when charge_state is MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY (if not, fault reporting is not supported).</field>
+    </message>
+```
+
+
+Questions:
+- It is desirable to move static fields like the `type` (battery chemistry) and `battery_function` out of the new message because they only need to be read once, and afterwards are dead weight.
+  For this to be OK, the information either has to be non-essential (i.e might never be provided) or guaranteed to be sent in another message (this info is present in [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO)).
+  - Is it non-essential?
+  - If it is essential, do we leave it in the message or mandate sending of `SMART_BATTERY_INFO`?
+- Do we need all the other fields?
+- Are there any other fields missing?
+
+
+## Battery Voltages
+
+The proposed battery message is below.
+
+This assumes that the reason you might need the individual battery voltages is in order to identify that a particular cell has a significantly different voltage, and is hence in fault.
+It simply sends information about which cells are in fault, providing battery manufacturers a way of reporting more detailed debugging information.
+
+```xml
+    <message id="???" name="BATTERY_VOLTAGE_FAULT">
+      <description>Battery information. Updates GCS with flight controller battery status. Smart batteries also use this message, but may additionally send SMART_BATTERY_INFO.</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="index">Cell index (0 by default). This is iterated for every 64 cells, allowing very large cell fault information. </field>
+      <field type="uint64_t" name="fault_mask">Fault/health indications. .</field>
+    </message>
+```
+
+## Migration/Discovery
+
+`BATTERY_STATUS` consumes significant bandwidth: sending `BATTERY_STATUS_V2` at the same time would just increase the problem.
+
+[
+What are options here?
+- Add support for either format in QGC/Mission Planner etc.
+- Flight stack send `BATTERY_STATUS` but ground station can request BATTERY_STATUS_V2 and turn off BATTERY_STATUS_V2 using SET_INTERVAL?
+- In a few releases we allow ground stations to set BATTERY_STATUS_V2 by default. 
+]
+
+
+
+# Alternatives
+
+TBD
+
+# Unresolved Questions
+
+TBD
+
+# References
+  * ?
+
+
+

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -11,7 +11,6 @@
 This RFC proposes:
 - a new `BATTERY_STATUS_V2` message that has a single cumulative voltage value rather than individual cell voltage arrays.
 - a new (optional) `BATTERY_VOLTAGES` message that can be scaled to as many cells as needed, and which reports them as faults.
-- mechanisms to ease supporting both message types until we can eventually deprecate `BATTERY_STATUS`
 
   
 # Motivation
@@ -112,28 +111,22 @@ This assumes that the smart battery is capable of providing the long term trend 
 
 ## SMART_BATTERY_INFO
 
-TBD:
+[SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO) is already deployed and it is not clear if it can be modified. It may be possible to extend.
 
-
-No changes are required to [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO) fields
-
-Note however that it must be streamed at a low rate in order to allow detection of battery change, and should also be sent when the battery changes. 
-We should specify the rate.
+Add note that it must be streamed at a low rate in order to allow detection of battery change, and should also be sent when the battery changes. 
 
 Questions:
-- What low rate is OK for streaming? is there another alternative?
+- What low rate is OK for streaming? is there another alternative for tracking battery change
+- Perhaps charge_state, mode, and fault_bitmask could be combined into a single uint32_t status? (Feedback comment: the concept of a "charge state" doesn't make a lot of sense. It's either charging, discharging, or idle. If it's not charging/discharging due to some error, that would be indicated using one of the other fault flags. Having separate enums to convey some "charge state" is effectively redundant, since it's just telling you to look at the fault flags to understand why the "charge state" is abnormal. The same argument might be applied to mode.
+- 
 
 
 ## Migration/Discovery
 
 `BATTERY_STATUS` consumes significant bandwidth: sending `BATTERY_STATUS_V2` at the same time would just increase the problem.
 
-[
-What are options here?
-- Add support for either format in QGC/Mission Planner etc.
-- Flight stack send `BATTERY_STATUS` but ground station can request BATTERY_STATUS_V2 and turn off BATTERY_STATUS using SET_INTERVAL?
-- In a few releases we allow ground stations to set BATTERY_STATUS_V2 by default. 
-]
+The proposal here is that GCS should support both messages for the forseeable future.
+Flight stacks should manage their own migration after relevant ground stations have been updated.
 
 
 # Alternatives

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -143,7 +143,7 @@ The proposed message is:
       <entry value="16384" name="MAV_BATTERY_STATUS_FLAGS_FAULT_SHORT_CIRCUIT">
         <description>
           Short circuit event detected.
-          The battery (or may not) may still be safe to use (check other flags).
+          The battery may or may not be safe to use (check other flags).
         </description>
       </entry>
       <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -6,6 +6,7 @@
     - [Add MAV_BATTERY_CHARGE_STATE_CHARGING #1068](https://github.com/mavlink/mavlink/pull/1068)
     - dronecan / DSDL : [WIP smart battery messages](https://github.com/dronecan/DSDL/pull/7) 
     - [DS-013 Pixhawk Smart Battery Standard](https://docs.google.com/document/d/1xYBhhgjND_RS2W3Hq0Seyc-R661ge3zonk9DTIyHclc/edit) v0.4.0
+    - [Common: rename SMART_BATTERY_INFO to BATTERY_INFO and add SOH](https://github.com/mavlink/mavlink/pull/2070)
 
   
 # Summary
@@ -41,7 +42,7 @@ The proposed message is:
     <message id="369" name="BATTERY_STATUS_V2">
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).
-        Static/invariant battery information is sent in SMART_BATTERY_INFO.
+        Static/invariant battery information is sent in BATTERY_INFO.
         Note that smart batteries should set the MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL bit to indicate that supplied capacity values are relative to a battery that is known to be full.
         Power monitors would not set this bit, indicating that capacity_consumed is relative to drone power-on, and that other values are estimated based on the assumption that the battery was full on power-on.
       </description>
@@ -189,13 +190,13 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
   - Better to be lightweight.
 - `percent_remaining` changed from int8 to uint8 (and max value set to invalid value).
   This is consistent with other MAVLink percentage fields.
-- removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant.
+- removes `battery_function` and `type` (chemistry) as these are present in `BATTERY_INFO` and are invariant.
   ```xml
      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
   ```
-  - A GCS that needs invariant information should read `SMART_BATTERY_INFO` on startup
-  - A vehicle that allows battery swapping must stream `SMART_BATTERY_INFO` (at low rate) to ensure that battery changes are notifie (and ideally also emit it on battery change).
+  - A GCS that needs invariant information should read `BATTERY_INFO` on startup
+  - A vehicle that allows battery swapping must stream `BATTERY_INFO` (at low rate) to ensure that battery changes are notifie (and ideally also emit it on battery change).
 - New `battery_status` (`MAV_BATTERY_STATUS_FLAGS`) replaces [`fault_bitmask`](https://mavlink.io/en/messages/common.html#MAV_BATTERY_FAULT), [`charge_state`](https://mavlink.io/en/messages/common.html#MAV_BATTERY_CHARGE_STATE) and [`mode`](https://mavlink.io/en/messages/common.html#MAV_BATTERY_MODE)
   ```xml
   <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
@@ -260,14 +261,11 @@ This assumes that the smart battery is capable of providing the long term trend 
     </message>
 ```
 
-## SMART_BATTERY_INFO
+## BATTERY_INFO
 
-[SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO) is already deployed and it is not clear if it can be modified. It may be possible to extend.
+[BATTERY_INFO](https://mavlink.io/en/messages/common.html#BATTERY_INFO) is WIP in common. This has been renamed from `SMART_BATTERY_INFO` as there were no known implementations.
 
 Add note that it must be streamed at a low rate in order to allow detection of battery change, and should also be sent when the battery changes. 
-
-Questions:
-- What low rate is OK for streaming? is there another alternative for tracking battery change
  
 
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -61,10 +61,11 @@ The proposed message is:
 ```xml
     <enum name="MAV_BATTERY_STATUS_FLAGS" bitmask="true">
       <description>Battery status flags for fault, health and state indication.</description>
-      <entry value="1" name="MAV_BATTERY_STATUS_FLAGS_READY_TO_USE">
+      <entry value="1" name="MAV_BATTERY_STATUS_FLAGS_NOT_READY_TO_USE">
         <description>
-          The battery is ready to use (fly).
-          Set if the battery has no known issues that would make it unsafe to fly with. This includes critical faults, such as those that would set MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE or MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY).
+          The battery is not ready to use (fly).
+          Set if the battery has faults that would make it unsafe to fly with.
+          It aggregates other serious faults, like MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE, MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY and others (at manufacturer/integrator discretion).
         </description>
       </entry>
       <entry value="2" name="MAV_BATTERY_STATUS_FLAGS_CHARGING">
@@ -75,7 +76,7 @@ The proposed message is:
       <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_CELL_BALANCING">
         <description>
           Battery is cell balancing (during charging).
-          Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
+          Not ready to use (MAV_BATTERY_STATUS_FLAGS_NOT_READY_TO_USE may be set).
         </description>
       </entry>
       <entry value="8" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_IMBALANCE">
@@ -87,7 +88,7 @@ The proposed message is:
       <entry value="16" name="MAV_BATTERY_STATUS_FLAGS_AUTO_DISCHARGING">
         <description>
           Battery is auto discharging (towards storage level).
-          Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
+          Not ready to use (MAV_BATTERY_STATUS_FLAGS_NOT_READY_TO_USE would be set).
         </description>
       </entry>
       <entry value="32" name="MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -64,8 +64,8 @@ The proposed message is:
       <entry value="1" name="MAV_BATTERY_STATUS_FLAGS_NOT_READY_TO_USE">
         <description>
           The battery is not ready to use (fly).
-          Set if the battery has faults that would make it unsafe to fly with.
-          It aggregates other serious faults, like MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE, MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY and others (at manufacturer/integrator discretion).
+          Set if the battery has faults or other conditions that make it unsafe to fly with.
+          Note: It will be the logical OR of other status bits (chosen by the manufacturer/integrator).
         </description>
       </entry>
       <entry value="2" name="MAV_BATTERY_STATUS_FLAGS_CHARGING">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -75,7 +75,7 @@ The proposed message is:
           Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
         </description>
       </entry>
-      <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_BALANCING">
+      <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_CELL_BALANCING">
         <description>
           Battery is cell balancing (during charging).
           Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -228,7 +228,7 @@ The proposed battery message is:
     <message id="371" name="BATTERY_CELL_VOLTAGES">
       <description>Battery cell voltages.
         This message is provided primarily for cell fault debugging.
-        For batteries with more than 10 cells the message should be sent multiple times, iterating the index value.
+        For batteries with more than 12 cells the message should be sent multiple times, iterating the index value.
         It should be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -80,7 +80,7 @@ The proposed battery message is:
 	For batteries with more than 10 cells the message should be sent multiple times, iterating the index value.
 	It should not be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 10 cells.</field>
+      <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>
       <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 12 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
     </message>
 ```

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -107,10 +107,10 @@ The proposed message is:
       </entry>
       <entry value="128" name="MAV_BATTERY_STATUS_FLAGS_PROTECTIONS_ENABLED">
         <description>
-          Automatic battery protection monitoring is enabled. 
+          Automatic battery protection monitoring is enabled.
           When enabled, the system will monitor for certain kinds of faults, such as cells being over-voltage.
           If a fault is triggered then and protections are enabled then a safety fault (MAV_BATTERY_STATUS_FLAGS_FAULT_PROTECTION_SYSTEM) will be set and power from the battery will be stopped.
-          Note that the associated fault (such as MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_VOLT) should always be set whether or not the protection system is engaged.
+          Note that battery protection monitoring should only be enabled when the vehicle is landed. Once the vehicle is armed, or starts moving, the protections should be disabled to prevent false positives from disabling the output.
         </description>
       </entry>
       <entry value="256" name="MAV_BATTERY_STATUS_FLAGS_FAULT_PROTECTION_SYSTEM">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -228,7 +228,7 @@ The proposed battery message is:
     <message id="371" name="BATTERY_CELL_VOLTAGES">
       <description>Battery cell voltages.
         This message is provided primarily for cell fault debugging.
-        For batteries with more than 12 cells the message should be sent multiple times, iterating the index value.
+        For batteries with more than 126 cells the message should be sent multiple times, iterating the index value.
         It should be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint16_t" name="id" instance="true">Battery ID</field>
       <field type="uint16_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 12 cells.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -48,7 +48,7 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
       <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
       <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
       <field type="int32_t" name="energy_consumed" units="hJ" invalid="-1">Consumed energy, -1: Energy consumption estimate not provided.</field>
-      <field type="int8_t" name="battery_remaining" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: Remaining battery energy is not provided.</field>
+      <field type="int8_t" name="percent_remaining" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: Remaining battery energy is not provided.</field>
       <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
       <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
       <field type="uint8_t" name="mode" enum="MAV_BATTERY_MODE">Battery mode. Default (0) is that battery mode reporting is not supported or battery is in normal-use mode.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -67,6 +67,7 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 
 - Do we need all the other fields?
 - Are there any other fields missing?
+- `current_consumed`, `percent_remaining`, `time_remaining` all tell much the same the same story, and can be estimated from each other. Do we need all of these, and if so which ones?
 
 
 ## Battery Cell Voltages

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -66,7 +66,8 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 
 - Do we need all the other fields?
 - Are there any other fields missing?
-- `current_consumed`, `percent_remaining`, `time_remaining` all tell much the same the same story, and can be estimated from each other. Do we need all of these, and if so which ones?
+- `current_consumed`, `percent_remaining`, `time_remaining` all tell much the same story, and can be estimated from each other. Do we need all of these, and if so which ones?
+- Perhaps charge_state, mode, and fault_bitmask could be combined into a single uint32_t status? (Feedback comment: the concept of a "charge state" doesn't make a lot of sense. It's either charging, discharging, or idle. If it's not charging/discharging due to some error, that would be indicated using one of the other fault flags. Having separate enums to convey some "charge state" is effectively redundant, since it's just telling you to look at the fault flags to understand why the "charge state" is abnormal. The same argument might be applied to mode.
 
 
 ## Battery Cell Voltages

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -5,7 +5,7 @@
 	- [common: added voltage and current multipliers to BATTERY_STATUS #233](https://github.com/ArduPilot/mavlink/pull/233)
     - [Add MAV_BATTERY_CHARGE_STATE_CHARGING #1068](https://github.com/mavlink/mavlink/pull/1068)
     - dronecan / DSDL : [WIP smart battery messages](https://github.com/dronecan/DSDL/pull/7) 
-- [DS-013 Pixhawk Smart Battery Standard](https://docs.google.com/document/d/1xYBhhgjND_RS2W3Hq0Seyc-R661ge3zonk9DTIyHclc/edit) v0.4.0
+    - [DS-013 Pixhawk Smart Battery Standard](https://docs.google.com/document/d/1xYBhhgjND_RS2W3Hq0Seyc-R661ge3zonk9DTIyHclc/edit) v0.4.0
 
   
 # Summary

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -5,6 +5,7 @@
 	- [common: added voltage and current multipliers to BATTERY_STATUS #233](https://github.com/ArduPilot/mavlink/pull/233)
     - [Add MAV_BATTERY_CHARGE_STATE_CHARGING #1068](https://github.com/mavlink/mavlink/pull/1068)
     - dronecan / DSDL : [WIP smart battery messages](https://github.com/dronecan/DSDL/pull/7) 
+- [DS-013 Pixhawk Smart Battery Standard](https://docs.google.com/document/d/1xYBhhgjND_RS2W3Hq0Seyc-R661ge3zonk9DTIyHclc/edit) v0.4.0
 
   
 # Summary

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -72,7 +72,9 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
   <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
   ```
   - This is an estimated "convenience" value which can be calculated as well or better by a GCS, in particular on multi-battery systems (from original charge, `current_consumed` and looking at the rate of `current` over some time period).
-  - Better to be lightweight. 
+  - Better to be lightweight.
+- `percent_remaining` changed from int8 to uint8 (and max value set to invalid value).
+  This is consistent with other MAVLink percentage fields.
 - removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant.
   ```xml
      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
@@ -107,7 +109,6 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
       </entry>
   ``` 
 
--
 
 ## Battery Cell Voltages
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -35,6 +35,7 @@ There are three parts to the design:
 The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
+- removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
 
 
 ```xml
@@ -47,7 +48,6 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
       <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
       <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
       <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
-      <field type="int32_t" name="energy_consumed" units="hJ" invalid="-1">Consumed energy, -1: Energy consumption estimate not provided.</field>
       <field type="int8_t" name="percent_remaining" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: Remaining battery energy is not provided.</field>
       <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
       <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -36,14 +36,16 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
 - removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
-
+- removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant. A GCS that needs this information should request it from that message on startup. NOTE THIS MEANS that the chemistry and function of a particular battery ID must be invariant!
+  ```xml
+     <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+  ```
 
 ```xml
     <message id="???" name="BATTERY_STATUS_V2">
       <description>Battery information. Updates GCS with flight controller battery status. Smart batteries also use this message, but may additionally send SMART_BATTERY_INFO.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
-      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX for unknown temperature.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
       <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -161,7 +161,7 @@ The proposed message is:
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
-      <entry value="4,294,967,295" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
+      <entry value="4294967295" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
         <description>Reserved (not used). If set, this will indicate that an additional status field exists for higher status values.</description>
       </entry>
     </enum>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -117,8 +117,7 @@ Add note that it must be streamed at a low rate in order to allow detection of b
 
 Questions:
 - What low rate is OK for streaming? is there another alternative for tracking battery change
-- Perhaps charge_state, mode, and fault_bitmask could be combined into a single uint32_t status? (Feedback comment: the concept of a "charge state" doesn't make a lot of sense. It's either charging, discharging, or idle. If it's not charging/discharging due to some error, that would be indicated using one of the other fault flags. Having separate enums to convey some "charge state" is effectively redundant, since it's just telling you to look at the fault flags to understand why the "charge state" is abnormal. The same argument might be applied to mode.
-- 
+ 
 
 
 ## Migration/Discovery

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -69,7 +69,6 @@ The proposed message is:
       <entry value="2" name="MAV_BATTERY_STATUS_FLAGS_CHARGING">
         <description>
           Battery is charging.
-          Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
         </description>
       </entry>
       <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_CELL_BALANCING">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -41,8 +41,8 @@ The proposed message is:
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX field not provided.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
-      <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge (estimate). -1: field not provided.</field>
-      <field type="int32_t" name="current_remaining" units="mAh" invalid="-1">Remaining charge (estimate). -1: field not provided.</field>
+      <field type="uint32_t" name="current_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge (estimate). UINT32_MAX: field not provided.</field>
+      <field type="uint32_t" name="current_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (estimate). UINT32_MAX: field not provided.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health/ready-to-use indications.</field>
     </message>
@@ -67,11 +67,12 @@ With `MAV_BATTERY_FAULT` having the following **additions** (from `MAV_BATTERY_C
 The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) but:
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
+- `current_consumed` has changed from an `int32_t` to a `uint32_t`. This allows future proofs from 32767 mAh limit to 4294967295 mAh 
 - removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
 - adds `current_remaining`(mAh) estimate.
   - This allows a GCS to more accurately determine available current and remaining time than inferring from the `current_consumed` and `percent_remaining`.
   - Note that this also gives the current reliably on plug-in. All the other information provided by messages (other than `percent_remaining`) assumes that the battery was full when it was plugged in.
-- change `current` from a `int16_t` (cA) to a `int32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof.
+- change `current` from a `int16_t` (cA) to a `uint32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof. The value is absolute - if you're charging the value can be assumed to be in a reversed direction.
 - removes `time_remaining`.
   ```xml
   <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -4,6 +4,7 @@
     - [16-cell support #1747](https://github.com/mavlink/mavlink/pull/1747)
 	- [common: added voltage and current multipliers to BATTERY_STATUS #233](https://github.com/ArduPilot/mavlink/pull/233)
     - [Add MAV_BATTERY_CHARGE_STATE_CHARGING #1068](https://github.com/mavlink/mavlink/pull/1068)
+    - dronecan / DSDL : [WIP smart battery messages](https://github.com/dronecan/DSDL/pull/7) 
 
   
 # Summary
@@ -18,6 +19,7 @@ This RFC proposes:
 The motivation is to:
 - reduce the memory required for battery reporting ([anecdotal evidence](https://github.com/ArduPilot/mavlink/pull/233#issuecomment-976197179) indicates cases with 15% of bandwidth on a default RF channel).
 - Provide a cleaner message and design for both implementers and consumers.
+- Align with DroneCan battery messages to ease transport and data conversion across different transports.
 
 The [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) has two arrays that can be used to report individual cell voltages (up to 14), or a single cumulative voltage, and which cannot be truncated.
 The vast majority of consumers are only interested in the total battery voltage, and either sum the battery cells or get the cumulative voltage.

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -98,7 +98,7 @@ Questions:
 [
 What are options here?
 - Add support for either format in QGC/Mission Planner etc.
-- Flight stack send `BATTERY_STATUS` but ground station can request BATTERY_STATUS_V2 and turn off BATTERY_STATUS_V2 using SET_INTERVAL?
+- Flight stack send `BATTERY_STATUS` but ground station can request BATTERY_STATUS_V2 and turn off BATTERY_STATUS using SET_INTERVAL?
 - In a few releases we allow ground stations to set BATTERY_STATUS_V2 by default. 
 ]
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -43,7 +43,6 @@ The proposed message is:
       <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
       <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: Remaining battery energy is not provided.</field>
-      <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health/ready-to-use indications.</field>
     </message>
 ```
@@ -68,6 +67,12 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
 - removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
+- removes `time_remaining`.
+  ```xml
+  <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
+  ```
+  - This is an estimated "convenience" value which can be calculated as well or better by a GCS, in particular on multi-battery systems (from original charge, `current_consumed` and looking at the rate of `current` over some time period).
+  - Better to be lightweight. 
 - removes `battery_function` and `type` (chemistry) as these are present in `SMART_BATTERY_INFO` and invariant.
   ```xml
      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
@@ -89,7 +94,6 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 
 - Do we need all the other fields?
 - Are there any other fields missing?
-- `current_consumed`, `percent_remaining`, `time_remaining` all tell much the same story, and can be estimated from each other. Do we need all of these, and if so which ones?
 - Should we have `MAV_BATTERY_FAULT` for critical level "just before deep discharge"? The battery can know this, and it might prevent over discharge.
   ```xml
       <entry value="1024" name="BATTERY_FAULT_CRITICAL_LEVEL">

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -42,7 +42,7 @@ The proposed message is:
       <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
       <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
       <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
-      <field type="int8_t" name="percent_remaining" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: Remaining battery energy is not provided.</field>
+      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: Remaining battery energy is not provided.</field>
       <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health/ready-to-use indications.</field>
     </message>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -155,10 +155,9 @@ The proposed message is:
       </entry>
       <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL">
         <description>
-          Battery capacity values are relative to a known-full battery.
-          If set: the supplied capacity_consumed and capacity_remaining are relative to battery full.
-          If unset: capacity_consumed is relative to drone power-on, and capacity_remaining estimated from capacity_consumed and the assumption that the battery was full at power on.
-          This bit should be set by smart batteries and unset for power modules.
+          Battery capacity_consumed and capacity_remaining values are relative to a full battery (they sum to the total capacity of the battery).
+          This flag would be set for a smart battery that can accurately determine its remaining charge across vehicle reboots and discharge/recharge cycles.
+          If unset the capacity_consumed indicates the consumption since vehicle power-on, as measured using a power monitor. The capacity_remaining, if provided, indicates the estimated remaining capacity on the assumption that the battery was full on vehicle boot.
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -38,7 +38,7 @@ The proposed message is:
     <message id="???" name="BATTERY_STATUS_V2">
       <description>Battery dynamic information. This should be streamed (nominally at 1Hz). Static battery information is sent in SMART_BATTERY_INFO.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX field not provided.</field>
+      <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="current_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge (estimate). UINT32_MAX: field not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -81,7 +81,7 @@ The proposed battery message is:
 	It should not be streamed at very low rate (less than once a minute) or streamed only on request.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="uint8_t" name="index">Cell index (0 by default). This can be iterated for batteries with more than 10 cells.</field>
-      <field type="uint16_t[10]" name="voltages" units="mV" invalid="[0]">Battery voltage of 10 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
+      <field type="uint16_t[12]" name="voltages" units="mV" invalid="[0]">Battery voltage of 10 cells at current index. Cells above the valid cell count for this battery should be set to 0.</field>
     </message>
 ```
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -42,6 +42,7 @@ The proposed message is:
       <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
       <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge (estimate). -1: field not provided.</field>
+      <field type="int32_t" name="current_remaining" units="mAh" invalid="-1">Remaining charge (estimate). -1: field not provided.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health/ready-to-use indications.</field>
     </message>
@@ -67,6 +68,9 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
 - removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
+- adds `current_remaining`(mAh) estimate.
+  - This allows a GCS to more accurately determine available current and remaining time than inferring from the `current_consumed` and `percent_remaining`.
+  - Note that this also gives the current reliably on plug-in. All the other information provided by messages (other than `percent_remaining`) assumes that the battery was full when it was plugged in.
 - change `current` from a `int16_t` (cA) to a `int32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof.
 - removes `time_remaining`.
   ```xml
@@ -109,7 +113,6 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
         <description>Battery is not ready/safe to use. Check other bitmasks for reasons.</description>
       </entry>
   ``` 
-- Is the size of the `current` field large enough. It has maximum value of 327.67A. We could make it a float or a uint_16 and change units to mA.
 
 
 ## Battery Cell Voltages

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -47,10 +47,10 @@ The proposed message is:
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
-      <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
-      <field type="int32_t" name="current" units="mA" invalid="INT32_MAX">Battery current (through all cells/loads). Positive value when discharging and negative if charging. INT32_MAX: field not provided.</field>
-      <field type="uint32_t" name="capacity_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge. UINT32_MAX: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
-      <field type="uint32_t" name="capacity_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
+      <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
+      <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
+      <field type="float" name="capacity_consumed" units="Ah" invalid="NaN">Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
+      <field type="float" name="capacity_remaining" units="Ah" invalid="NaN">Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="uint32_t" name="status_flags" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -140,22 +140,19 @@ The proposed message is:
       <entry value="8192" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_CURRENT">
         <description>Over-current fault.</description>
       </entry>
-      <entry value="16384" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_FAIL">
-        <description>One or more cells have failed. The battery (or may not) may still be safe to fly.</description>
-      </entry>    
-      <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_SHORT_CIRCUIT">
+      <entry value="16384" name="MAV_BATTERY_STATUS_FLAGS_FAULT_SHORT_CIRCUIT">
         <description>
           Short circuit event detected.
           The battery (or may not) may still be safe to use (check other flags).
         </description>
       </entry>
-      <entry value="65536" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">
+      <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">
         <description>Voltage not compatible power rail voltage (batteries on same power rail should have similar voltage).</description>
       </entry>
-      <entry value="131072" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_FIRMWARE">
+      <entry value="65536" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_FIRMWARE">
         <description>Battery firmware is not compatible with current autopilot firmware.</description>
       </entry>
-      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
+      <entry value="131072" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
         <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
       </entry>
     </enum>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -38,11 +38,11 @@ The proposed message is:
     <message id="???" name="BATTERY_STATUS_V2">
       <description>Battery dynamic information. This should be streamed (nominally at 1Hz). Static battery information is sent in SMART_BATTERY_INFO.</description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX for unknown temperature.</field>
-      <field type="uint32_t" name="voltage" units="mV" invalid="[UINT32_MAX]">Battery voltage (total).</field>
-      <field type="int16_t" name="current" units="cA" invalid="UINT16_MAX">Battery current (through all cells/loads). Positive if discharging, negative if charging. UINT16_MAX: field not provided.</field>
-      <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge, -1: Current consumption estimate not provided.</field>
-      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: Remaining battery energy is not provided.</field>
+      <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the battery. INT16_MAX field not provided.</field>
+      <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
+      <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
+      <field type="int32_t" name="current_consumed" units="mAh" invalid="-1">Consumed charge (estimate). -1: field not provided.</field>
+      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health/ready-to-use indications.</field>
     </message>
 ```
@@ -67,6 +67,7 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
 - removes the cell voltage arrays: `voltages` and `voltages_ext`
 - adds `voltage`, the total cell voltage. This is a uint32_t to allow batteries with more than 65V.
 - removes `energy_consumed`. This essentially duplicates `current_consumed` for most purposes, and `current_consumed`/mAh is nearly ubiquitous.
+- change `current` from a `int16_t` (cA) to a `int32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof.
 - removes `time_remaining`.
   ```xml
   <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -147,7 +147,7 @@ The proposed message is:
         </description>
       </entry>
       <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">
-        <description>Voltage not compatible power rail voltage (batteries on same power rail should have similar voltage).</description>
+        <description>Voltage not compatible with power rail voltage (batteries on same power rail should have similar voltage).</description>
       </entry>
       <entry value="65536" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_FIRMWARE">
         <description>Battery firmware is not compatible with current autopilot firmware.</description>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -42,16 +42,16 @@ The proposed message is:
         This should be streamed (nominally at 1Hz).
         Static/invariant battery information is sent in SMART_BATTERY_INFO.
 
-        The full-battery charge is current_remaining + current_consumed, iff both values are supplied.
+        The full-battery charge can be inferred from current_remaining and percent_remaining if both values are supplied.
         The `current_remaining` field should only be sent if it is guaranteed to be near-accurate.
-        Power monitors typically should not send the `current_remaining` field as it can only be accurate if the battery is fully charged when the drone is turned on.
+        Power monitors do not normally send the `current_remaining` field as it can only be accurate if the battery is fully charged when the drone is turned on.
         (A GCS can use `current_remaining` being invalid as a trigger to notify the user to fully charge the battery before flight).
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="uint32_t" name="voltage" units="mV" invalid="UINT32_MAX">Battery voltage (total). UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="current" units="mA" invalid="UINT32_MAX">Battery current (through all cells/loads). UINT32_MAX: field not provided.</field>
-      <field type="uint32_t" name="current_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge (from full). UINT32_MAX: field not provided. Note: Power modules report the current consumed since they were last turned on (the expectation is that batteries are fully charged before turning on the vehicle).</field>
+      <field type="uint32_t" name="current_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge (since vehicle powered on). UINT32_MAX: field not provided. Note: For power modules the expectation is that batteries are fully charged before turning on the vehicle.</field>
       <field type="uint32_t" name="current_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (until empty). UINT32_MAX: field not provided. Note: Power monitors should not set this value.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
       <field type="uint32_t" name="battery_status" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, and readiness status indications.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -179,7 +179,7 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
     A GCS can use this to prompt that batteries be fully charged for power modules.
 - Note that with capacity consumed and remaining, you have the full capacity and you could calculate the percentage remaining.
   However percentage remaining is supplied anyway, as the other values are optional, and this is actually the one value that most users really want.
-- change `current` from a `int16_t` (cA) to a `uint32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof. The value is absolute - if you're charging the value can be assumed to be in a reversed direction.
+- change `current` from a `int16_t` (cA) to a `int32_t` (mA). Maximum size was previously 327.67A, which is not large enough to be future proof. New value gives up to 2,147,483A. The value is positive when discharging, and negative when charging.
 - removes `time_remaining`.
   ```xml
   <field type="uint32_t" name="time_remaining" units="s" invalid="UINT32_MAX">Remaining battery time (estimated), UINT32_MAX: Remaining battery time estimate not provided.</field>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -75,27 +75,39 @@ The proposed message is:
           Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
         </description>
       </entry>
-      <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_AUTO_DISCHARGING">
+      <entry value="4" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_BALANCING">
+        <description>
+          Battery is cell balancing (during charging).
+          Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
+        </description>
+      </entry>
+      <entry value="8" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_IMBALANCE">
+        <description>
+          Battery cells are not balanced.
+          Not ready to use.
+        </description>
+      </entry>
+      <entry value="16" name="MAV_BATTERY_STATUS_FLAGS_AUTO_DISCHARGING">
         <description>
           Battery is auto discharging (towards storage level).
           Not ready to use (MAV_BATTERY_STATUS_FLAGS_READY_TO_USE would not be set).
         </description>
       </entry>
-      <entry value="8" name="MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE">
+      <entry value="32" name="MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE">
         <description>
           Battery requires service (not safe to fly). 
           This is set at vendor discretion.
           It is likely to be set for most faults, and may also be set according to a maintenance schedule (such as age, or number of recharge cycles, etc.).
         </description>
       </entry>
-      <entry value="16" name="MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY">
+      <entry value="64" name="MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY">
         <description>
           Battery is faulty and cannot be repaired (not safe to fly). 
           This is set at vendor discretion.
           The battery should be disposed of safely.
         </description>
       </entry>
-      <entry value="32" name="MAV_BATTERY_STATUS_FLAGS_PROTECTIONS_ENABLED">
+      <entry value="128" name="MAV_BATTERY_STATUS_FLAGS_PROTECTIONS_ENABLED">
         <description>
           Automatic battery protection monitoring is enabled. 
           When enabled, the system will monitor for certain kinds of faults, such as cells being over-voltage.
@@ -103,41 +115,47 @@ The proposed message is:
           Note that the associated fault (such as MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_VOLT) should always be set whether or not the protection system is engaged.
         </description>
       </entry>
-      <entry value="64" name="MAV_BATTERY_STATUS_FLAGS_FAULT_PROTECTION_SYSTEM">
+      <entry value="256" name="MAV_BATTERY_STATUS_FLAGS_FAULT_PROTECTION_SYSTEM">
         <description>
           The battery fault protection system had detected a fault and cut all power from the battery.
           This will only trigger if MAV_BATTERY_STATUS_FLAGS_PROTECTIONS_ENABLED is set.
           Other faults like MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_VOLT may also be set, indicating the cause of the protection fault.
         </description>
       </entry>
-      <entry value="128" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_VOLT">
+      <entry value="512" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_VOLT">
         <description>One or more cells are above their maximum voltage rating.</description>
       </entry>
-      <entry value="256" name="MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_VOLT">
+      <entry value="1024" name="MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_VOLT">
         <description>
           One or more cells are below their minimum voltage rating.
           A battery that had deep-discharged might be irrepairably damaged, and set both MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_VOLT and MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY.
         </description>
       </entry>
-      <entry value="512" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_TEMPERATURE">
+      <entry value="2048" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_TEMPERATURE">
         <description>Over-temperature fault.</description>
       </entry>
-      <entry value="1024" name="MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_TEMPERATURE">
+      <entry value="4096" name="MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_TEMPERATURE">
         <description>Under-temperature fault.</description>
       </entry>
-      <entry value="2048" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_CURRENT">
+      <entry value="8192" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_CURRENT">
         <description>Over-current fault.</description>
       </entry>
-      <entry value="4096" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_FAIL">
+      <entry value="16384" name="MAV_BATTERY_STATUS_FLAGS_FAULT_CELL_FAIL">
         <description>One or more cells have failed. The battery (or may not) may still be safe to fly.</description>
+      </entry>    
+      <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_SHORT_CIRCUIT">
+        <description>
+          Short circuit event detected.
+          The battery (or may not) may still be safe to use (check other flags).
+        </description>
       </entry>
-      <entry value="8192" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">
+      <entry value="65536" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_VOLTAGE">
         <description>Voltage not compatible power rail voltage (batteries on same power rail should have similar voltage).</description>
       </entry>
-      <entry value="16384" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_FIRMWARE">
+      <entry value="131072" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_FIRMWARE">
         <description>Battery firmware is not compatible with current autopilot firmware.</description>
       </entry>
-      <entry value="32768" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
+      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
         <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
       </entry>
     </enum>

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -108,6 +108,7 @@ The message is heavily based on [BATTERY_STATUS](https://mavlink.io/en/messages/
         <description>Battery is not ready/safe to use. Check other bitmasks for reasons.</description>
       </entry>
   ``` 
+- Is the size of the `current` field large enough. It has maximum value of 327.67A. We could make it a float or a uint_16 and change units to mA.
 
 
 ## Battery Cell Voltages

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -3,6 +3,7 @@
   * Related issues: 
     - [16-cell support #1747](https://github.com/mavlink/mavlink/pull/1747)
 	- [common: added voltage and current multipliers to BATTERY_STATUS #233](https://github.com/ArduPilot/mavlink/pull/233)
+    - [Add MAV_BATTERY_CHARGE_STATE_CHARGING #1068](https://github.com/mavlink/mavlink/pull/1068)
 
   
 # Summary
@@ -109,6 +110,9 @@ This assumes that the smart battery is capable of providing the long term trend 
 ```
 
 ## SMART_BATTERY_INFO
+
+TBD:
+
 
 No changes are required to [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO) fields
 

--- a/text/001x-battery_improvements.md
+++ b/text/001x-battery_improvements.md
@@ -54,7 +54,7 @@ The proposed message is:
       <field type="uint32_t" name="current_consumed" units="mAh" invalid="UINT32_MAX">Consumed charge (since vehicle powered on). UINT32_MAX: field not provided. Note: For power modules the expectation is that batteries are fully charged before turning on the vehicle.</field>
       <field type="uint32_t" name="current_remaining" units="mAh" invalid="UINT32_MAX">Remaining charge (until empty). UINT32_MAX: field not provided. Note: Power monitors should not set this value.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT32_MAX: field not provided.</field>
-      <field type="uint32_t" name="battery_status" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, and readiness status indications.</field>
+      <field type="uint32_t" name="status_flags" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, and readiness status indications.</field>
     </message>
 ```
 


### PR DESCRIPTION
The [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) has two arrays that can be used to report individual cell voltages (up to 14), or a single cumulative voltage, and which cannot be truncated.
The vast majority of consumers are only interested in the total battery voltage, and either sum the battery cells or get the cumulative voltage.

This RFC proposes two new messages, separating out the individual voltage for cells as cell fault information. The result is a simpler message to understand and use. We've also liased with UAVCAN in order to ensure that the messages are compatible with what UAVCAN is doing.
