### PR TITLE
RFC16: Standard Modes: Metadata support/overrides and dynamic modes

### DIFF
--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -188,7 +188,7 @@ A new message will be added for enumerating all available modes (standard, base,
 - If there is a direct correlation between a standard mode and a custom mode this should be treated as just one mode (the standard mode) and emitted once.
 - The GCS can request this message using `MAV_CMD_REQUEST_MESSAGE`, specifying either "send all modes" or "send mode with this index".
 - The message will include a `mode_name` field that can act as both a key for determining mode metadata, or as a fallback string if the GCS has no metadata for the mode.
-  This can be used to provide metadata (or minimally a mode name) for dynamic modes, and to provide customised data for any other mode.
+  This can be used to override metadata on existing modes, for example to enhance standard metadata with additional information about autopilot-specific behaviour, or can provide metadata for any other static or dynamic mode.
   The field must be human readable and autopilot-unique.
   Generally it need not be set for standard modes, where the ground station might be expected to already have metadata.
   For more information see [Modes Metadata](#modes-metadata) below.

--- a/text/0016-standard-modes.md
+++ b/text/0016-standard-modes.md
@@ -235,6 +235,9 @@ This would be emitted on mode change, and also streamed at low rate (a GCS might
     </message>
 ```
 
+Note that the current base and custom modes are currently (and should continue to be) published in the [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT).
+Including the standard mode in the `HEARTBEAT` was discussed and discarded.
+See "Get Current mode from HEARTBEAT" section below.
 
 ## Dynamic Mode Changes
 


### PR DESCRIPTION
This is an updated standard modes proposal that provides two new optional features:
- Mechanism for modes to provide a link to metadata definitions.
  - This enables overriding of default standard mode definitions, allowing an autopilot to provide more specific information about the particular behaviour of the standard mode on the autopilot (within the scope allowed by the standard mode). This is needed because the standard modes are broad, and you might want to provide additional information/configuration.
  - This can also be used to provide metadata custom modes and dynamic modes (such as luascripts and offboard controllers)
- Dynamic modes, such as might be provided by a luascript or offboard controller (a message send on mode changes).
  - This allows for alternative implementations of standard/other modes to be provided at runtime.

This is fully optional, and compatible with the existing service.
